### PR TITLE
Fixed: REPLACE action does not call replaceHref function

### DIFF
--- a/src/History.js
+++ b/src/History.js
@@ -1,5 +1,5 @@
 import { replace } from './actions'
-import { NAVIGATE } from './constants'
+import { NAVIGATE, REPLACE } from './constants'
 
 export default class History {
   constructor (store) {
@@ -22,7 +22,9 @@ export default class History {
     if (action.type === NAVIGATE) {
       if (href && action.href !== href) {
         this.pushHref(action.href)
-      } else {
+      }
+    } else if (action.type === REPLACE) {
+      if (href && action.href !== href) {
         this.replaceHref(action.href)
       }
     }

--- a/test/History.js
+++ b/test/History.js
@@ -1,5 +1,5 @@
 import test from 'tape'
-import { NAVIGATE } from '../src/constants'
+import { NAVIGATE, REPLACE } from '../src/constants'
 import History from '../src/History'
 
 test('popstate listener', t => {
@@ -20,11 +20,11 @@ test('push or replace on navigate', t => {
   t.plan(2)
 
   const history = new History()
-  history.getCurrentHref = () => '/foo'
+  history.getCurrentHref = () => '/'
   history.replaceHref = href => t.equal(href, '/foo')
   history.pushHref = href => t.equal(href, '/foo/bar')
 
-  history.update({ type: NAVIGATE, href: '/foo' })
+  history.update({ type: REPLACE, href: '/foo' })
   history.update({ type: NAVIGATE, href: '/foo/bar' })
 })
 


### PR DESCRIPTION
This left the history replacement (i.e. redirection) function nonfunctional.

Note on test: The test failed (i.e. froze) in its original state with just the action name adjusted. I set the starting path to `'/'` to ensure a difference between current and new path.